### PR TITLE
- Updated bank account type for Marginalen Bank.

### DIFF
--- a/src/SwedishBankAccounts/Bank.cs
+++ b/src/SwedishBankAccounts/Bank.cs
@@ -42,7 +42,7 @@ public record Bank(string Name, Range[] SortingCodeRange, BankAccountNumberType 
                 new Bank("Lån & Spar Bank Sverige", new[] { new Range(9630, 9639) }, new BankAccountNumberType1A()),
                 new Bank("Länsförsäkringar Bank", new[] { new Range(3400, 3409), new Range(9060, 9069) }, new BankAccountNumberType1A()),
                 new Bank("Länsförsäkringar Bank", new[] { new Range(9020, 9029) }, new BankAccountNumberType1B()),
-                new Bank("Marginalen Bank", new[] { new Range(9230, 9239) }, new BankAccountNumberType1B()),
+                new Bank("Marginalen Bank", new[] { new Range(9230, 9239) }, new BankAccountNumberType1A()),
                 new Bank("Multitude Bank", new[] { new Range(9070, 9079) }, new BankAccountNumberType1A()),
                 new Bank("Nordax Bank", new[] { new Range(9640, 9649) }, new BankAccountNumberType1B()),
                 new Bank("Nordea", new[] 


### PR DESCRIPTION
Updated BankAccount type for Marginalen Bank from Typa 1B to 1A according to: https://www.bankgirot.se/globalassets/dokument/anvandarmanualer/bankernaskontonummeruppbyggnad_anvandarmanual_sv.pdf